### PR TITLE
Add Collapse

### DIFF
--- a/snippets/Collapse.md
+++ b/snippets/Collapse.md
@@ -38,7 +38,7 @@ class Collapse extends React.Component {
   
   render() {
     return (
-      <React.Fragment>
+      <div>
         <button style={this.style.buttonStyle} onClick={this.toggleCollapse}>
           Show/Hide Content
         </button>

--- a/snippets/Collapse.md
+++ b/snippets/Collapse.md
@@ -1,0 +1,69 @@
+### Collapse
+
+Renders a component with collapsible content.
+
+Use the value of the `collapsed` prop to determine the initial state of the content (collapsed/expanded).
+Set the `state` of the component to the value of the `collapsed` prop (cast to a boolean value) and bind the `toggleCollapse` method to the component's context.
+Use an object, `style`, to hold the styles for individual components and their states.
+Create a method, `toggleCollapse`, which uses `Component.prototype.setState` to change the component's `state` from collapsed to expanded and vice versa.
+In the `render()` method, use a `React.Fragment` to wrap both the `<button>` that alters the component's `state` and the content of the component, passed down via `props.children`.
+Determine the appearance of the content, based on `state.collapsed` and apply the appropriate CSS rules from the `style` object.
+Finally, update the value of the `aria-expanded` attribute based on `state.collapsed` to make the component accessible.
+
+```jsx
+class Collapse extends React.Component {
+  constructor(props) {
+    super(props);
+    this.state = {
+      collapsed: !!props.collapsed
+    };
+    this.style = {
+      collapsed: {
+        display: 'none'
+      },
+      expanded: {
+        display: 'block'
+      },
+      buttonStyle: {
+        display: 'block',
+        width: '100%'
+      }
+    };
+    this.toggleCollapse = this.toggleCollapse.bind(this);
+  }
+  
+  toggleCollapse() {
+    this.setState({ collapsed: !this.state.collapsed });
+  }
+  
+  render() {
+    return (
+      <React.Fragment>
+        <button style={this.style.buttonStyle} onClick={this.toggleCollapse}>
+          Show/Hide Content
+        </button>
+        <div 
+          style= {this.state.collapsed ? this.style.collapsed : this.style.expanded} 
+          aria-expanded = {this.state.collapsed}
+        >
+          {this.props.children}
+        </div>
+      </React.Fragment>
+    );
+  }
+}
+```
+
+```jsx
+ReactDOM.render(
+  <Collapse>
+    <h1>This is a collapse</h1>
+    <p>Hello world!</p>
+  </Collapse>,
+  document.getElementById('root')
+);
+```
+
+<!-- tags: visual,children,state,class -->
+
+<!-- expertise: 2 -->

--- a/snippets/Collapse.md
+++ b/snippets/Collapse.md
@@ -33,7 +33,7 @@ class Collapse extends React.Component {
   }
   
   toggleCollapse() {
-    this.setState({ collapsed: !this.state.collapsed });
+    this.setState(state => ({ collapsed: !state.collapsed });
   }
   
   render() {

--- a/snippets/Collapse.md
+++ b/snippets/Collapse.md
@@ -48,7 +48,7 @@ class Collapse extends React.Component {
         >
           {this.props.children}
         </div>
-      </React.Fragment>
+      </div>
     );
   }
 }

--- a/snippets/Collapse.md
+++ b/snippets/Collapse.md
@@ -64,6 +64,6 @@ ReactDOM.render(
 );
 ```
 
-<!-- tags: visual,children,state,class -->
+<!-- tags: visual,children,state,fragment,class -->
 
 <!-- expertise: 2 -->

--- a/snippets/Collapse.md
+++ b/snippets/Collapse.md
@@ -6,7 +6,7 @@ Use the value of the `collapsed` prop to determine the initial state of the cont
 Set the `state` of the component to the value of the `collapsed` prop (cast to a boolean value) and bind the `toggleCollapse` method to the component's context.
 Use an object, `style`, to hold the styles for individual components and their states.
 Create a method, `toggleCollapse`, which uses `Component.prototype.setState` to change the component's `state` from collapsed to expanded and vice versa.
-In the `render()` method, use a `React.Fragment` to wrap both the `<button>` that alters the component's `state` and the content of the component, passed down via `props.children`.
+In the `render()` method, use a `<div>` to wrap both the `<button>` that alters the component's `state` and the content of the component, passed down via `props.children`.
 Determine the appearance of the content, based on `state.collapsed` and apply the appropriate CSS rules from the `style` object.
 Finally, update the value of the `aria-expanded` attribute based on `state.collapsed` to make the component accessible.
 
@@ -64,6 +64,6 @@ ReactDOM.render(
 );
 ```
 
-<!-- tags: visual,children,state,fragment,class -->
+<!-- tags: visual,children,state,class -->
 
 <!-- expertise: 2 -->


### PR DESCRIPTION
A simple collapse component:

- Uses `state`.
- Binds an event listener callback to its own context.
- Uses `props.children` to render content.
- Is accessible via `aria-expanded`.
- Has some CSS-in-JS (as unopinionated and minimal as possible).