### PR TITLE
Update Modal Dialogue notes about styling

### DIFF
--- a/snippets/ModalDialog.md
+++ b/snippets/ModalDialog.md
@@ -133,7 +133,7 @@ ModalDialog.show({
 ```
 
 #### Notes:
-* This component includes a lot of CSS, which might conflict with other CSS in your project.
+* This component includes a lot of CSS, which might conflict with other CSS in your project. It is recomended that the modal a direct child of the body tag.
 * A more up-to-date method with lower compatibility is to use [Portals](https://reactjs.org/docs/portals.html) in React 16+.
 
 <!-- tags: visual,static,children,state,class -->

--- a/snippets/ModalDialog.md
+++ b/snippets/ModalDialog.md
@@ -133,7 +133,7 @@ ModalDialog.show({
 ```
 
 #### Notes:
-* This component includes a lot of CSS, which might conflict with other CSS in your project. It is recomended that the modal a direct child of the body tag.
+* This component includes a lot of CSS, which might conflict with other CSS in your project. It is recomended for the modal to be a direct child of the body tag.
 * A more up-to-date method with lower compatibility is to use [Portals](https://reactjs.org/docs/portals.html) in React 16+.
 
 <!-- tags: visual,static,children,state,class -->


### PR DESCRIPTION
Since this uses a 'portal' that is agnostic of implementation, the note should be updated to reflect this could just go right next to the body tag. This should be easy enough to do with another react-dom, but if people can't figure that out on their own...