### PR TITLE
Update input snippets to use destructuring syntax

### DIFF
--- a/snippets/Input.md
+++ b/snippets/Input.md
@@ -8,12 +8,12 @@ Render an `<input>` element with the appropriate attributes and use the `callbac
 ```jsx
 function Input ({ callback, type = 'text', disabled = false, readOnly = false, placeholder = '' }) {
   return (
-    <input 
-      type={type} 
-      disabled={disabled} 
-      readOnly={readOnly} 
+    <input
+      type={type}
+      disabled={disabled}
+      readOnly={readOnly}
       placeholder={placeholder}
-      onChange={(event) => callback(event.target.value)} 
+      onChange={({ target: { value }}) => callback(value)}
     />
   );
 }

--- a/snippets/Input.md
+++ b/snippets/Input.md
@@ -13,7 +13,7 @@ function Input ({ callback, type = 'text', disabled = false, readOnly = false, p
       disabled={disabled}
       readOnly={readOnly}
       placeholder={placeholder}
-      onChange={({ target: { value }}) => callback(value)}
+      onChange={({ target: { value } }) => callback(value)}
     />
   );
 }

--- a/snippets/Select.md
+++ b/snippets/Select.md
@@ -12,7 +12,7 @@ function Select ({ values, callback, disabled = false, readonly = false, selecte
     <select
       disabled={disabled}
       readOnly={readonly}
-      onChange={({ target : { value }}) => callback(value)}
+      onChange={({ target : { value } }) => callback(value)}
     >
       {values.map(([value, text]) => <option selected={selected === value}value={value}>{text}</option>)}
     </select>

--- a/snippets/Select.md
+++ b/snippets/Select.md
@@ -9,12 +9,12 @@ Use the `values` array to pass an array of `[value, text]` elements and the `sel
 ```jsx
 function Select ({ values, callback, disabled = false, readonly = false, selected }) {
   return (
-    <select 
-      disabled={disabled} 
-      readOnly={readonly} 
-      onChange={(event) => callback(event.target.value)} 
+    <select
+      disabled={disabled}
+      readOnly={readonly}
+      onChange={({ target : { value }}) => callback(value)}
     >
-      {values.map(v => <option selected={selected === v[0]}value={v[0]}>{v[1]}</option>)}
+      {values.map(([value, text]) => <option selected={selected === value}value={value}>{text}</option>)}
     </select>
   );
 }

--- a/snippets/Select.md
+++ b/snippets/Select.md
@@ -4,7 +4,7 @@ Renders a `<select>` element that uses a callback function to pass its value to 
 
 Use object destructuring to set defaults for certain attributes of the `<select>` element.
 Render a `<select>` element with the appropriate attributes and use the `callback` function in the `onChange` event to pass the value of the textarea to the parent.
-Use the `values` array to pass an array of `[value, text]` elements and the `selected` attribute to define the initial `value` of the `<select>` element.
+Use destructuring on the `values` array to pass an array of `value` and  `text` elements and the `selected` attribute to define the initial `value` of the `<select>` element.
 
 ```jsx
 function Select ({ values, callback, disabled = false, readonly = false, selected }) {

--- a/snippets/TextArea.md
+++ b/snippets/TextArea.md
@@ -8,13 +8,13 @@ Render a `<textarea>` element with the appropriate attributes and use the `callb
 ```jsx
 function TextArea ({ callback, cols = 20, rows = 2, disabled = false, readOnly = false, placeholder='' }) {
   return (
-    <textarea 
+    <textarea
       cols={cols}
       rows={rows}
-      disabled={disabled} 
-      readOnly={readOnly} 
+      disabled={disabled}
+      readOnly={readOnly}
       placeholder={placeholder}
-      onChange={(event) => callback(event.target.value)} 
+      onChange={({ target : { value } }) => callback(value)}
     />
   );
 }


### PR DESCRIPTION
Minor fixes that include the use of destructuring suggested by @skatcat31 