### PR TITLE
Replace `map` with `forEach`

### DIFF
--- a/README.md
+++ b/README.md
@@ -409,7 +409,7 @@ function MultiselectCheckbox({ options, onChange }) {
   const [data, setData] = React.useState(options);
 
   const toggle = item => {
-    data.map((_, key) => {
+    data.forEach((_, key) => {
       if (data[key].label === item.label) data[key].checked = !item.checked;
     });
     setData([...data]);


### PR DESCRIPTION
`forEach` is  more semantically correct to use in the MultiselectCheckbox example.

Codesandbox with `forEach` https://codesandbox.io/s/30-seconds-of-react-multiselectcheckbox-tk9qf