### PR TITLE
[FIX] Typo in Readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -420,7 +420,7 @@ A hook that implements `setInterval` in a declarative manner.
 - Create a custom hook that takes a `callback` and a `delay`.
 - Use the `React.useRef()` hook to create a `ref` for the callback function.
 - Use the `React.useEffect()` hook to remember the latest callback.
-- Use the `Rect.useEffect()` hook to set up the interval and clean up.
+- Use the `React.useEffect()` hook to set up the interval and clean up.
 
 ```jsx
 const useInterval = (callback, delay) => {
@@ -529,7 +529,7 @@ A hook that implements `setTimeout` in a declarative manner.
 - Create a custom hook that takes a `callback` and a `delay`.
 - Use the `React.useRef()` hook to create a `ref` for the callback function.
 - Use the `React.useEffect()` hook to remember the latest callback.
-- Use the `Rect.useEffect()` hook to set up the timeout and clean up.
+- Use the `React.useEffect()` hook to set up the timeout and clean up.
 
 ```jsx
 const useTimeout = (callback, delay) => {

--- a/snippets/useInterval.md
+++ b/snippets/useInterval.md
@@ -8,7 +8,7 @@ A hook that implements `setInterval` in a declarative manner.
 - Create a custom hook that takes a `callback` and a `delay`.
 - Use the `React.useRef()` hook to create a `ref` for the callback function.
 - Use the `React.useEffect()` hook to remember the latest callback.
-- Use the `Rect.useEffect()` hook to set up the interval and clean up.
+- Use the `React.useEffect()` hook to set up the interval and clean up.
 
 ```jsx
 const useInterval = (callback, delay) => {

--- a/snippets/useTimeout.md
+++ b/snippets/useTimeout.md
@@ -8,7 +8,7 @@ A hook that implements `setTimeout` in a declarative manner.
 - Create a custom hook that takes a `callback` and a `delay`.
 - Use the `React.useRef()` hook to create a `ref` for the callback function.
 - Use the `React.useEffect()` hook to remember the latest callback.
-- Use the `Rect.useEffect()` hook to set up the timeout and clean up.
+- Use the `React.useEffect()` hook to set up the timeout and clean up.
 
 ```jsx
 const useTimeout = (callback, delay) => {


### PR DESCRIPTION
Change `Rect.useEffect()` to `React.useEffect()`
