### PR TITLE
Issue fix on accordion collapse behavior

### DIFF
--- a/snippets/Accordion.md
+++ b/snippets/Accordion.md
@@ -56,7 +56,7 @@ function Accordion(props) {
     <div className="wrapper">
       {items.map(({ props }) => (
         <AccordionItem
-          isCollapsed={bindIndex === props.index}
+          isCollapsed={bindIndex !== props.index}
           label={props.label}
           handleClick={() => changeItem(props.index)}
           children={props.children}


### PR DESCRIPTION
<!-- Use a descriptive title, prefix it with [FIX], [FEATURE] or [ENHANCEMENT] if applicable (use only one) -->

## Description

Prop `isCollapsed` should only be `true` if the selected index is not the same as the item index.

## PR Type
- [x] Snippets, Tests & Tags (new snippets, updated snippets, re-tagging of snippets, added/updated tests)
- [ ] Tools, Scripts & Automation (anything related to files in the scripts folder, Gatsby, website, Travis CI or Netlify)
- [ ] General, Typos, Misc. & Meta (everything related to content, typos, general stuff and meta files in the repository - e.g. the issue template)
- [ ] Other (please specifiy in the description above)

## Guidelines
- [x] I have read the guidelines in the [CONTRIBUTING](https://github.com/30-seconds/30-seconds-of-react/blob/master/CONTRIBUTING.md) document.
