### PR TITLE
add immediate support in useInterval

### DIFF
--- a/snippets/useInterval.md
+++ b/snippets/useInterval.md
@@ -3,7 +3,7 @@ title: useInterval
 tags: hooks,effect,intermediate
 ---
 
-A hook that implements `setInterval` in a declarative manner.
+A hook that implements `setInterval` with immediate/not-immediate option in a declarative manner.
 
 - Create a custom hook that takes a `callback` and a `delay`.
 - Use the `React.useRef()` hook to create a `ref` for the callback function.
@@ -11,7 +11,7 @@ A hook that implements `setInterval` in a declarative manner.
 - Use the `React.useEffect()` hook to set up the interval and clean up.
 
 ```jsx
-const useInterval = (callback, delay) => {
+const useInterval = (callback, delay, immediate = false) => {
   const savedCallback = React.useRef();
 
   React.useEffect(() => {
@@ -22,16 +22,19 @@ const useInterval = (callback, delay) => {
     function tick() {
       savedCallback.current();
     }
+    if (immediate) {
+      tick();
+    }
     if (delay !== null) {
       let id = setInterval(tick, delay);
       return () => clearInterval(id);
     }
-  }, [delay]);
+  }, [delay, immediate]);
 };
 ```
 
 ```jsx
-const Timer = props => {
+const Timer = (props) => {
   const [seconds, setSeconds] = React.useState(0);
   useInterval(() => {
     setSeconds(seconds + 1);


### PR DESCRIPTION
<!-- Use a descriptive title, prefix it with [FIX], [FEATURE] or [ENHANCEMENT] if applicable (use only one) -->

## Description
<!-- Write a detailed description of your changes/additions here -->
<!-- If your PR resolves an issue, please state "Resolves #(issue number)" to help maintainers process it faster -->
<!-- If you think your PR will cause breaking changes, require changes in the documentation etc, please be so kind as to explain what, where and how -->
Updated the `useInterval` with immediate/not-immediate option.

## PR Type
- [x] Snippets, Tests & Tags (new snippets, updated snippets, re-tagging of snippets, added/updated tests)
- [ ] Tools, Scripts & Automation (anything related to files in the scripts folder, Gatsby, website, Travis CI or Netlify)
- [ ] General, Typos, Misc. & Meta (everything related to content, typos, general stuff and meta files in the repository - e.g. the issue template)
- [ ] Other (please specifiy in the description above)

## Guidelines
- [x] I have read the guidelines in the [CONTRIBUTING](https://github.com/30-seconds/30-seconds-of-react/blob/master/CONTRIBUTING.md) document.
