### PR TITLE
Update AutoLink.md

### DIFF
--- a/snippets/AutoLink.md
+++ b/snippets/AutoLink.md
@@ -10,7 +10,7 @@ Renders a string as plaintext, with URLs converted to appropriate `<a>` elements
 
 ```jsx
 function AutoLink({ text }) {
-  const delimiter = /((?:https?:\/\/)?(?:(?:[a-z0-9]?(?:[a-z0-9\-]{1,61}[a-z0-9])?\.[^\.|\s])+[a-z\.]*[a-z]+|(?:25[0-5]|2[0-4][0-9]|[01]?[0-9][0-9]?)(?:\.(?:25[0-5]|2[0-4][0-9]|[01]?[0-9][0-9]?)){3})(?::\d{1,5})*[a-z0-9.,_\/~#&=;%+?\-\\(\\)]*)/gi;
+  const delimiter = /(^|[\s\n]|<[A-Za-z]*\/?>)((?:https?|ftp):\/\/[\-A-Z0-9+@#\/%?=()~_|!:,.;]*[\-A-Z0-9+@#\/%=~()_|])/gi;
 
   return (
     <React.Fragment>


### PR DESCRIPTION
The old delimiter make these words like so `.something, .milk....` become the link without http or https, so I think these are wrong and I have use other regex to make this function become better.