### PR TITLE
Update useCopyToClipboard.md

### DIFF
--- a/snippets/useCopyToClipboard.md
+++ b/snippets/useCopyToClipboard.md
@@ -36,8 +36,8 @@ const useCopyToClipboard = text => {
 
   const [copied, setCopied] = React.useState(false);
 
-  const copy = React.useCallback(() => {
-    if (!copied) setCopied(copyToClipboard(text));
+  const copy = React.useCallback(copyText => {
+    if (!copied) setCopied(copyToClipboard(copyText || text));
   }, [text]);
   React.useEffect(() => () => setCopied(false), [text]);
 


### PR DESCRIPTION
In most times, we copy text when we handle some action(like click),so supprt a parameter in handler is uesful